### PR TITLE
fix(mdns): Publish service via mDNS on all network interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,12 +84,11 @@
   },
   "dependencies": {
     "mdns": "^2.2.10",
-    "network-address": "^1.0.0",
     "os-locale": "^1.4.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
-    "redux": "^3.0.5",
-    "react-redux": "^4.0.2"
+    "react-redux": "^4.0.2",
+    "redux": "^3.0.5"
   },
   "private": true,
   "config": {

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,6 @@
 const http = require('http')
 const os = require('os')
 const mdns = require('mdns')
-const address = require('network-address')
 
 function handleScan (webContents, request, response) {
   var body = ''
@@ -34,7 +33,7 @@ function startServer (webContents) {
 
   server.listen(0, '0.0.0.0', function onStarted () {
     const options = {
-      networkInterface: address(),
+      interfaceIndex: 0,
       host: os.hostname()
     }
     const ad = mdns.createAdvertisement(mdns.tcp('esrhttp'), server.address().port, options, function registered () {})


### PR DESCRIPTION
This allows mDNS to publish its service over all available network interfaces as described here
http://agnat.github.io/node_mdns/user_guide.html under 'Interface Indices'.